### PR TITLE
fixed version upgrade issues with new releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.erb eol=lf
 *.pp eol=lf
 *.sh eol=lf
+*.epp eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc
@@ -21,3 +22,6 @@
 /convert_report.txt
 /update_report.txt
 .DS_Store
+.project
+.envrc
+/inventory.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,87 +1,41 @@
 ---
 stages:
-  - test_2.4.1
-  - test_2.1.9
+  - syntax
+  - unit
+
+cache:
+  paths:
+    - vendor/bundle
 
 before_script:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
-  - gem update bundler
+  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
-  - bundle install --without system_tests --path vendor/bundle
+  - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-cache:
-  key: "$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
-  paths:
-    - vendor/bundle
-
-
-rubocop-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
-  variables:
-    PUPPET_GEM_VERSION: ~> 5.0
+syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.3-Puppet ~> 6:
+  stage: syntax
+  image: ruby:2.5.3
   script:
-    - bundle exec rake rubocop
-
-syntax-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
+    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
   variables:
-    PUPPET_GEM_VERSION: ~> 5.0
-  script:
-    - bundle exec rake syntax lint
+    PUPPET_GEM_VERSION: '~> 6'
 
-metadata-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
-  variables:
-    PUPPET_GEM_VERSION: ~> 5.0
+parallel_spec-Ruby 2.5.3-Puppet ~> 6:
+  stage: unit
+  image: ruby:2.5.3
   script:
-    - bundle exec rake metadata_lint
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 6'
 
-rspec-puppet-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
-  variables:
-    PUPPET_GEM_VERSION: ~> 5.0
-    CHECK: spec
+parallel_spec-Ruby 2.4.5-Puppet ~> 5:
+  stage: unit
+  image: ruby:2.4.5
   script:
-    - bundle update
-    - bundle exec rake $CHECK
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 5'
 
-rubocop-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-  script:
-    - bundle exec rake rubocop
-
-syntax-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-  script:
-    - bundle exec rake syntax lint
-
-metadata-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-  script:
-    - bundle exec rake metadata_lint
-
-rspec-puppet-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-    CHECK: spec
-  script:
-    - bundle update
-    - bundle exec rake $CHECK

--- a/.pdkignore
+++ b/.pdkignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc
@@ -21,3 +22,21 @@
 /convert_report.txt
 /update_report.txt
 .DS_Store
+.project
+.envrc
+/inventory.yaml
+/appveyor.yml
+/.fixtures.yml
+/Gemfile
+/.gitattributes
+/.gitignore
+/.gitlab-ci.yml
+/.pdkignore
+/Rakefile
+/rakelib/
+/.rspec
+/.rubocop.yml
+/.travis.yml
+/.yardopts
+/spec/
+/.vscode/

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,1 @@
+--relative

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -8,14 +10,23 @@ AllCops:
   Exclude:
   - bin/*
   - ".vendor/**/*"
-  - Gemfile
-  - Rakefile
+  - "**/Gemfile"
+  - "**/Rakefile"
   - pkg/**/*
   - spec/fixtures/**/*
   - vendor/**/*
+  - "**/Puppetfile"
+  - "**/Vagrantfile"
+  - "**/Guardfile"
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
+GetText/DecorateString:
+  Description: We don't want to decorate test output.
+  Exclude:
+  - spec/**/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -65,6 +76,12 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 RSpec/MessageSpies:
   EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+  - lib/puppet/parser/functions/**/*
+  - spec/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
@@ -72,6 +89,8 @@ Style/MethodCalledOnDoEndBlock:
 Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
+  Enabled: false
+Layout/IndentHeredoc:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -47,3 +47,7 @@ Gemfile:
       - gem: puppet-lint-unquoted_string-check
       - gem: puppet-lint-variable_contains_upcase
       - gem: puppet-lint-version_comparison-check
+
+spec/default_facts.yml:
+  extra_facts:
+    operatingsystemrelease: 18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,42 @@
 ---
-sudo: false
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system
-  - gem update bundler
+  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
 script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.4.1
-env:
-  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  - 2.5.3
+stages:
+  - static
+  - spec
+  - acceptance
+  -
+    if: tag =~ ^v\d
+    name: deploy
 matrix:
   fast_finish: true
   include:
     -
-      env: CHECK=rubocop
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      stage: static
     -
-      env: CHECK="syntax lint"
+      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.5
+      stage: spec
     -
-      env: CHECK=metadata_lint
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.3
+      stage: spec
     -
-      env: CHECK=release_checks
-    -
-      env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-      rvm: 2.1.9
+      env: DEPLOY_TO_FORGE=yes
+      stage: deploy
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
 branches:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Added support for Ubuntu 18.04
+* Replaced deprecated stankevich-python dependency a with puppet-python
+* Updated pdk version
+
+## Release 0.1.0
+
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,15 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place_or_version, fake_version = nil)
-  if place_or_version =~ %r{\A(git[:@][^#]*)#(.*)}
-    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
-  elsif place_or_version =~ %r{\Afile:\/\/(.*)}
-    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
+  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+
+  if place_or_version && (git_url = place_or_version.match(git_url_regex))
+    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
+    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
     [place_or_version, { require: false }]
-  end
-end
-
-def gem_type(place_or_version)
-  if place_or_version =~ %r{\Agit[:@]}
-    :git
-  elsif !place_or_version.nil? && place_or_version.start_with?('file:')
-    :file
-  else
-    :gem
   end
 end
 
@@ -24,17 +17,18 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '<= 2.0.4',                              require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
-  gem "travis",                                        require: false
+  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "travis",                                                  require: false
 end
 group :puppet_lint do
   gem "puppet-lint-absolute_classname-check",                      require: false
@@ -61,7 +55,6 @@ group :puppet_lint do
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
-puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,86 @@
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
+require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
 
-PuppetLint.configuration.send('relative')
+def changelog_user
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  return unless Rake.application.top_level_tasks.include? "changelog"
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
+
+PuppetLint.configuration.send('disable_relative')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature", "enhancement"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+EOM
+  end
+end
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,9 @@
+---
 version: 1.1.x.{build}
+branches:
+  only:
+    - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10
@@ -12,29 +17,23 @@ environment:
   matrix:
     -
       RUBY_VERSION: 24-x64
-      CHECK: syntax lint
-    -
-      RUBY_VERSION: 24-x64
-      CHECK: metadata_lint
-    -
-      RUBY_VERSION: 24-x64
-      CHECK: rubocop
-    -
-      PUPPET_GEM_VERSION: ~> 4.0
-      RUBY_VERSION: 21
-      CHECK: spec
-    -
-      PUPPET_GEM_VERSION: ~> 4.0
-      RUBY_VERSION: 21-x64
-      CHECK: spec
+      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
-      CHECK: spec
+      CHECK: parallel_spec
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
-      CHECK: spec
+      CHECK: parallel_spec
+    -
+      PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25
+      CHECK: parallel_spec
+    -
+      PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25-x64
+      CHECK: parallel_spec
 matrix:
   fast_finish: true
 install:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class duo_authproxy::config {
     path    => "${duo_authproxy::install_dir}/conf/authproxy.cfg",
     owner   => 'nobody',
     group   => 'root',
-    mode    => '0640',
+    mode    => '0400',
     content => Sensitive(template("${module_name}/authproxy.cfg.erb")),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,14 @@ class duo_authproxy (
   $proxy_type = undef,
 ) {
 
-  unless versioncmp($facts['python_version'], '2.6') >= 0 {
-    fail("${name} requires at least python version 2.6, you have ${facts['python_version']}.")
+  if $::operatingsystemrelease == '18.04' {
+    $python_version = 'python3_version'
+  }else {
+    $python_version = 'python_version'
+  }
+
+  unless versioncmp($facts[$python_version], '2.6') >= 0 {
+    fail("${name} requires at least python version 2.6, you have ${facts[$python_version]}.")
   }
 
   contain '::duo_authproxy::install'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,6 +22,13 @@ class duo_authproxy::install {
     proxy_server => $duo_authproxy::proxy_server,
     proxy_type   => $duo_authproxy::proxy_type,
   }
+  
+  -> exec { 'duoauthproxy-move':
+    command => "mv duoauthproxy-${duo_authproxy::version}*-src duoauthproxy-${duo_authproxy::version}-src",
+    cwd     => '/tmp',
+    path    => '/bin',
+    creates => $creates_path,
+  }
 
   -> exec { 'duoauthproxy-make':
     command     => 'make > duoauthproxy-make.log',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,7 @@ class duo_authproxy::install {
 
   ensure_packages($duo_authproxy::dep_packages)
 
-  $inst_cmd = "duoauthproxy-build/install --install-dir ${duo_authproxy::install_dir} --service-user nobody --create-init-script yes"
+  $inst_cmd = "duoauthproxy-build/install --install-dir ${duo_authproxy::install_dir} --service-user duo_authproxy_svc --log-group duo_authproxy_grp --create-init-script yes"
   $creates_path = "${duo_authproxy::install_dir}/${duo_authproxy::version}"
 
   archive { "/tmp/duoauthproxy-${duo_authproxy::version}-src.tgz":
@@ -22,7 +22,7 @@ class duo_authproxy::install {
     proxy_server => $duo_authproxy::proxy_server,
     proxy_type   => $duo_authproxy::proxy_type,
   }
-  
+
   -> exec { 'duoauthproxy-move':
     command => "mv duoauthproxy-${duo_authproxy::version}*-src duoauthproxy-${duo_authproxy::version}-src",
     cwd     => '/tmp',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "MiamiOH-duo_authproxy",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "Chris Edester",
   "summary": "Installs and configures Duo Authentication Proxy",
   "license": "GPL-3.0+",
@@ -13,12 +13,12 @@
       "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
-      "name": "stankevich/python",
-      "version_requirement": ">= 1.10.0 < 2.0.0"
+      "name": "puppet/python",
+      "version_requirement": ">= 1.10.0 < 4.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.1.0 < 4.0.0"
+      "version_requirement": ">= 1.1.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -55,7 +55,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     }
   ],
@@ -70,7 +71,7 @@
     "authentication",
     "ldap"
   ],
-  "pdk-version": "1.5.0",
-  "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
-  "template-ref": "1.5.0-0-gd1b3eca"
+  "pdk-version": "1.13.0",
+  "template-url": "pdk-default#1.13.0",
+  "template-ref": "1.13.0-0-g66e1443"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,8 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+operatingsystemrelease: 18.04
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,7 @@
-
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
-begin
-  require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
-rescue LoadError => loaderror
-  warn "Could not require spec_helper_local: #{loaderror.message}"
-end
+require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
 
 include RspecPuppetFacts
 
@@ -15,15 +10,24 @@ default_facts = {
   facterversion: Facter.version,
 }
 
-default_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml'))
-default_module_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
+default_fact_files = [
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml')),
+]
 
-if File.exist?(default_facts_path) && File.readable?(default_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_facts_path)))
+default_fact_files.each do |f|
+  next unless File.exist?(f) && File.readable?(f) && File.size?(f)
+
+  begin
+    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+  rescue => e
+    RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
+  end
 end
 
-if File.exist?(default_module_facts_path) && File.readable?(default_module_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_module_facts_path)))
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
 end
 
 RSpec.configure do |c|
@@ -33,4 +37,18 @@ RSpec.configure do |c|
     # by default Puppet runs at warning level
     Puppet.settings[:strict] = :warning
   end
+  c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
+  c.after(:suite) do
+  end
 end
+
+# Ensures that a module is defined
+# @param module_name Name of the module
+def ensure_module_defined(module_name)
+  module_name.split('::').reduce(Object) do |last_module, next_module|
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
+    last_module.const_get(next_module, false)
+  end
+end
+
+# 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
The duo authproxy latest packages now has numbers attached to it causing the module to not be able to install the duo authproxy. This error comes up when puppept runs:
Error: Working directory ```'/tmp/duoauthproxy-2.14.0-src' does not exist```. The tarball when extracted is ```duoauthproxy-2.14.0-bd60798-src``` and not ```duoauthproxy-2.14.0-src```
Before, this worked fine when the version was 2.7.0 but the newer versions breaks it.

To add to this, the recent version of duo authproxy(3.0.0) when extracted gives this ```duoauthproxy-3.0.0--src``` instead of ```duoauthproxy-3.0.0-src```. Duo also changed the ```--service-user```  in the install commad to ```duo_authproxy_svc --log-group duo_authproxy_grp```

This fixes all those issues. 