### PR TITLE
Increase timeout for the duoauthproxy-make step

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,6 +36,7 @@ class duo_authproxy::install {
     environment => ['PYTHON=python'],
     path        => $facts['path'],
     creates     => $creates_path,
+    timeout     => 1800,
     require     => Package[$duo_authproxy::dep_packages],
   }
 


### PR DESCRIPTION
On my machine (VM with single core processor), the make process takes significantly longer than the default `exec` timeout (300 seconds). Bumping it up to 1200 seconds should give enough time for most machines to finish.