### PR TITLE
Add parameter for exec timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Style/BlockDelimiters:
 Style/BracesAroundHashParameters:
   Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
     See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
+  Enabled: false
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact

--- a/.sync.yml
+++ b/.sync.yml
@@ -42,3 +42,5 @@ Rakefile:
 spec/default_facts.yml:
   extra_facts:
     operatingsystemrelease: 18.04
+spec/spec_helper.rb:
+  mock_with: ':rspec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
+## Release 1.1.0
+* Updated pdk version
+* Added parameter for exec timeout(default is 300 seconds)
+* Set correct owner for the `authproxy.cfg` file
+* Fixed metadata license syntax
+* Added Ubuntu 20.04 support
+* Fixed pdk validation warnings
+* Fixed deprecation warnings
 
+## Release 1.0.0
 * Added support for Ubuntu 18.04
 * Replaced deprecated stankevich-python dependency a with puppet-python
 * Updated pdk version

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
     config.add_pr_wo_labels = true
     config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",
@@ -61,11 +61,11 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
       },
       "Added" => {
         "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
+        "labels" => ["enhancement", "feature"],
       },
       "Fixed" => {
         "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
+        "labels" => ["bug", "documentation", "bugfix"],
       },
     }
   end
@@ -73,16 +73,15 @@ else
   desc 'Generate a Changelog from GitHub'
   task :changelog do
     raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+The changelog tasks depends on recent features of the github_changelog_generator gem.
 Please manually add it to your .sync.yml for now, and run `pdk update`:
 ---
 Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
 EOM
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class duo_authproxy::config {
   file { 'authproxy.cfg':
     ensure  => file,
     path    => "${duo_authproxy::install_dir}/conf/authproxy.cfg",
-    owner   => 'nobody',
+    owner   => 'duo_authproxy_svc',
     group   => 'root',
     mode    => '0400',
     content => Sensitive(template("${module_name}/authproxy.cfg.erb")),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class duo_authproxy (
   Hash $settings = {},
   $proxy_server = undef,
   $proxy_type = undef,
+  $exec_timeout = 300,
 ) {
 
   if $::operatingsystemrelease == '18.04' {
@@ -29,12 +30,12 @@ class duo_authproxy (
   contain 'duo_authproxy::config'
   contain 'duo_authproxy::service'
 
-  Class['::duo_authproxy::install']
-  -> Class['::duo_authproxy::config']
+  Class['duo_authproxy::install']
+  -> Class['duo_authproxy::config']
 
-  Class['::duo_authproxy::install']
-  ~> Class['::duo_authproxy::service']
+  Class['duo_authproxy::install']
+  ~> Class['duo_authproxy::service']
 
-  Class['::duo_authproxy::config']
-  ~> Class['::duo_authproxy::service']
+  Class['duo_authproxy::config']
+  ~> Class['duo_authproxy::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class duo_authproxy (
   $exec_timeout = 300,
 ) {
 
-  if $::operatingsystemrelease == '18.04' {
+  if ($::operatingsystemrelease == '18.04') or ($::operatingsystemrelease == '20.04') {
     $python_version = 'python3_version'
   }else {
     $python_version = 'python_version'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class duo_authproxy::install {
     command => "mv duoauthproxy-${duo_authproxy::version}*-src duoauthproxy-${duo_authproxy::version}-src",
     cwd     => '/tmp',
     path    => '/bin',
+    timeout => $duo_authproxy::exec_timeout,
     creates => $creates_path,
   }
 
@@ -35,6 +36,7 @@ class duo_authproxy::install {
     cwd         => "/tmp/duoauthproxy-${duo_authproxy::version}-src",
     environment => ['PYTHON=python'],
     path        => $facts['path'],
+    timeout     => $duo_authproxy::exec_timeout,
     creates     => $creates_path,
     require     => Package[$duo_authproxy::dep_packages],
   }
@@ -44,12 +46,14 @@ class duo_authproxy::install {
     cwd         => "/tmp/duoauthproxy-${duo_authproxy::version}-src",
     environment => ['PYTHON=python'],
     path        => $facts['path'],
+    timeout     => $duo_authproxy::exec_timeout,
     creates     => $creates_path,
   }
 
   -> exec { 'duoauthproxy-tag':
     command => "touch ${creates_path}",
     path    => $facts['path'],
+    timeout => $duo_authproxy::exec_timeout,
     creates => $creates_path,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
   "name": "MiamiOH-duo_authproxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Chris Edester",
   "summary": "Installs and configures Duo Authentication Proxy",
-  "license": "GPL-3.0+",
+  "license": "GPL-3.0",
   "source": "https://github.com/MiamiOH/puppet-duo_authproxy.git",
   "project_page": "https://github.com/MiamiOH/puppet-duo_authproxy",
   "issues_url": "https://github.com/MiamiOH/puppet-duo_authproxy/issues",
@@ -56,14 +56,15 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
   "tags": [
@@ -72,6 +73,6 @@
     "ldap"
   ],
   "pdk-version": "1.18.0",
-  "template-url": "pdk-default#1.18.0",
-  "template-ref": "tags/1.18.0-0-g095317c"
+  "template-url": "https://github.com/puppetlabs/pdk-templates#master",
+  "template-ref": "remotes/origin/master-0-ga58fd92"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
     "authentication",
     "ldap"
   ],
-  "pdk-version": "1.18.0",
+  "pdk-version": "2.1.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
   "template-ref": "remotes/origin/master-0-ga58fd92"
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -13,7 +13,10 @@ describe 'duo_authproxy::config' do
           is_expected.to contain_file('authproxy.cfg').with(
             'ensure'  => 'file',
             'path'    => '/opt/duoauthproxy/conf/authproxy.cfg',
-            'content' => "# Managed by Puppet.\n\n[main]\ndebug=true\n\n",
+            'owner'   => 'duo_authproxy_svc',
+            'group'   => 'root',
+            'mode'    => '0400',
+            'content' => 'Sensitive [value redacted]',
           )
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
This pull request adds an exec timeout for all the exec resources. The default timeout is 300 seconds and can be overwritten with the parameter `exec_timeout`(example: `exec_timeout => 3600`). This will resolve #17. Also, the issue #18 was fixed in this pull request so issue #18 can be closed: `https://github.com/MiamiOH/puppet-duo_authproxy/pull/11`. I also set the correct `authproxy.cfg` config file owner per the duo auth proxy documentation. In addition to adding the exec timeout parameter I also fixed some pdk validation issues for:
```
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:33:9)
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:34:12)
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:36:9)
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:37:12)
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:39:9)
pdk (WARNING): puppet-lint: absolute class name reference (manifests/init.pp:40:12)
```
This pull request also fixes unit test for the `config_spec.rb`. Since you set the content as Sensitive, in the unit test, specifying an actual content causes the unit test to fail per `pdk test unit --parallel`. See below:

```duo_authproxy::config on centos-7-x86_64 with settings is expected to contain File[authproxy.cfg] with ensure => "file", path => "/opt/duoauthproxy/conf/authproxy.cfg", owner => "duo_authproxy_svc", group => "root", mode => "0400" and content  supplied string
     Failure/Error:
       is_expected.to contain_file('authproxy.cfg').with(
         'ensure'  => 'file',
         'path'    => '/opt/duoauthproxy/conf/authproxy.cfg',
         'owner'   => 'duo_authproxy_svc',
         'group'   => 'root',
         'mode'    => '0400',
         'content' => "# Managed by Puppet.\n\n[main]\ndebug=true\n\n",
       )

       expected that the catalogue would contain File[authproxy.cfg] with content set to supplied string
       Diff:
       @@ -1,5 +1,2 @@
       -# Managed by Puppet.
       -
       -[main]
       -debug=true
       +Sensitive [value redacted]
```
Lastly, I also fixed some deprecation warnings as well. See below:

```
puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you
```
All pdk validation and unit tests passes with no issues now.

```
pdk (INFO): Using Ruby 2.7.2s .......
pdk (INFO): Using Puppet 7.5.0st syntax (**/*.pp).son).
pdk (INFO): Running all available validators...a.json).
pdk (INFO): Validator 'puppet-epp' skipped for '/home/tenajsystems/puppet-duo_authproxy'. No files matching '["**/*.epp"]' found to validate.
pdk (INFO): Validator 'task-name' skipped for '/home/tenajsystems/puppet-duo_authproxy'. No files matching '["tasks/**/*"]' found to validate.
pdk (INFO): Validator 'task-metadata-lint' skipped for '/home/tenajsystems/puppet-duo_authproxy'. No files matching '["tasks/*.json"]' found to validate.
┌ [✔] Running metadata validators ...
├── [✔] Checking metadata syntax (metadata.json tasks/*.json).
└── [✔] Checking module metadata style (metadata.json).
┌ [✔] Running puppet validators ...
├── [✔] Checking Puppet manifest syntax (**/*.pp).
└── [✔] Checking Puppet manifest style (**/*.pp).
┌ [✔] Running ruby validators ...
└── [✔] Checking Ruby code style (**/**.rb).
┌ [✔] Running tasks validators ...
├── [✔] Checking task names (tasks/**/*).
└── [✔] Checking task metadata style (tasks/*.json).
┌ [✔] Running yaml validators ...
└── [✔] Checking YAML syntax (**/*.yaml **/*.yml).

root@tenajsystems:/home/tenajsystems/puppet-duo_authproxy# pdk test unit --parallel
pdk (INFO): Using Ruby 2.7.2
pdk (INFO): Using Puppet 7.5.0
[✔] Preparing to run the unit tests.
4 processes for 4 specs, ~ 1 specs per process
Run options: exclude {:bolt=>true}
Run options: exclude {:bolt=>true}
Run options: exclude {:bolt=>true}
Run options: exclude {:bolt=>true}
.......................................................................

Finished in 9.27 seconds (files took 7.26 seconds to load)
8 examples, 0 failures

..

Finished in 9.12 seconds (files took 7.42 seconds to load)
16 examples, 0 failures

..

Finished in 9.37 seconds (files took 7.27 seconds to load)
16 examples, 0 failures

.....

Finished in 9.51 seconds (files took 7.28 seconds to load)
40 examples, 0 failures


80 examples, 0 failures

Took 17 seconds
```
Let me know if you have any questions.